### PR TITLE
Fix loop limit error

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -11,7 +11,7 @@ end
 RegisterServerEvent('esx_holdup:toofar')
 AddEventHandler('esx_holdup:toofar', function(robb)
     local _source = source
-    local xPlayer  = ESX.GetPlayerFromId(_source)
+    local xPlayers = ESX.GetPlayers()
     rob = false
     for i=1, #xPlayers, 1 do
          local xPlayer = ESX.GetPlayerFromId(xPlayers[i])


### PR DESCRIPTION
Resolves the "attempt to get length" error, which caused that the robbery didn't stop when going too far away from the zone, and sending notification to police officers.

Tested and working.